### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ CLPKittenPlaceholder is a category on UIImageView which leverages the awesome po
 	pod 'CLPKittenPlaceholder'
 ```
 
-CLPKittenPlaceholder builds on [AFNetworking](http://afnetworking.com)'s lovely [UIImageView category](http://cocoadocs.org/docsets/AFNetworking/2.0.3/Categories/UIImageView+AFNetworking.html). If you're using Cocoapods, this dependency will be resolved automatically.
+CLPKittenPlaceholder builds on [AFNetworking](http://afnetworking.com)'s lovely [UIImageView category](http://cocoadocs.org/docsets/AFNetworking/2.0.3/Categories/UIImageView+AFNetworking.html). If you're using CocoaPods, this dependency will be resolved automatically.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
